### PR TITLE
Add TLS mutual authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ metrics from an agent.
 Usage of mesos_exporter:
   -addr string
         Address to listen on (default ":9105")
+  -clientCert string
+        Path to Mesos client TLS certificate (.pem file)
+  -clientKey string
+        Path to Mesos client TLS key file (.pem file)
   -exportedSlaveAttributes string
         Comma-separated list of slave attributes to include in the corresponding metric
   -exportedTaskLabels string


### PR DESCRIPTION
Adds `-clientCertFile` and `-clientKeyFile` flags to allow users to specify TLS material for mutual authentication with a Mesos Master/Slave.