### PR TITLE
Publish exporter version information.

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -4,6 +4,15 @@ repository:
     path: github.com/mesos/mesos_exporter
 build:
     flags: -a
+    binaries:
+        - name: mesos_exporter
+          path: .
+    ldflags: |
+        -X {{repoPath}}/vendor/github.com/prometheus/common/version.Version={{.Version}}
+        -X {{repoPath}}/vendor/github.com/prometheus/common/version.Revision={{.Revision}}
+        -X {{repoPath}}/vendor/github.com/prometheus/common/version.Branch={{.Branch}}
+        -X {{repoPath}}/vendor/github.com/prometheus/common/version.BuildUser={{user}}@{{host}}
+        -X {{repoPath}}/vendor/github.com/prometheus/common/version.BuildDate={{date "20060102-15:04:05"}}
 tarball:
     files:
         - LICENSE

--- a/common.go
+++ b/common.go
@@ -158,8 +158,9 @@ type authInfo struct {
 
 type httpClient struct {
 	http.Client
-	url  string
-	auth authInfo
+	url       string
+	auth      authInfo
+	userAgent string
 }
 
 type metricCollector struct {
@@ -217,6 +218,7 @@ func authToken(httpClient *httpClient) string {
 			}).Error("Error creating HTTP request")
 			return ""
 		}
+		req.Header.Add("User-Agent", httpClient.userAgent)
 		req.Header.Add("Content-Type", "application/json")
 		res, err := httpClient.Do(req)
 		if err != nil {
@@ -254,6 +256,7 @@ func (httpClient *httpClient) fetchAndDecode(endpoint string, target interface{}
 		}).Error("Error creating HTTP request")
 		return false
 	}
+	req.Header.Add("User-Agent", httpClient.userAgent)
 	if httpClient.auth.username != "" && httpClient.auth.password != "" {
 		req.SetBasicAuth(httpClient.auth.username, httpClient.auth.password)
 	}

--- a/vendor/github.com/prometheus/common/version/info.go
+++ b/vendor/github.com/prometheus/common/version/info.go
@@ -1,0 +1,89 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"strings"
+	"text/template"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Build information. Populated at build-time.
+var (
+	Version   string
+	Revision  string
+	Branch    string
+	BuildUser string
+	BuildDate string
+	GoVersion = runtime.Version()
+)
+
+// NewCollector returns a collector which exports metrics about current version information.
+func NewCollector(program string) *prometheus.GaugeVec {
+	buildInfo := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: program,
+			Name:      "build_info",
+			Help: fmt.Sprintf(
+				"A metric with a constant '1' value labeled by version, revision, branch, and goversion from which %s was built.",
+				program,
+			),
+		},
+		[]string{"version", "revision", "branch", "goversion"},
+	)
+	buildInfo.WithLabelValues(Version, Revision, Branch, GoVersion).Set(1)
+	return buildInfo
+}
+
+// versionInfoTmpl contains the template used by Info.
+var versionInfoTmpl = `
+{{.program}}, version {{.version}} (branch: {{.branch}}, revision: {{.revision}})
+  build user:       {{.buildUser}}
+  build date:       {{.buildDate}}
+  go version:       {{.goVersion}}
+`
+
+// Print returns version information.
+func Print(program string) string {
+	m := map[string]string{
+		"program":   program,
+		"version":   Version,
+		"revision":  Revision,
+		"branch":    Branch,
+		"buildUser": BuildUser,
+		"buildDate": BuildDate,
+		"goVersion": GoVersion,
+	}
+	t := template.Must(template.New("version").Parse(versionInfoTmpl))
+
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, "version", m); err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+// Info returns version, branch and revision information.
+func Info() string {
+	return fmt.Sprintf("(version=%s, branch=%s, revision=%s)", Version, Branch, Revision)
+}
+
+// BuildContext returns goVersion, buildUser and buildDate information.
+func BuildContext() string {
+	return fmt.Sprintf("(go=%s, user=%s, date=%s)", GoVersion, BuildUser, BuildDate)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -63,6 +63,12 @@
 			"revisionTime": "2017-08-30T19:05:55Z"
 		},
 		{
+			"checksumSHA1": "91KYK0SpvkaMJJA2+BcxbVnyRO0=",
+			"path": "github.com/prometheus/common/version",
+			"revision": "61f87aac8082fa8c3c5655c7608d7478d46ac2ad",
+			"revisionTime": "2017-07-31T11:42:04Z"
+		},
+		{
 			"checksumSHA1": "ihxJIjxtbEYdQKwA0D0nRipj95I=",
 			"path": "github.com/prometheus/procfs",
 			"revision": "e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2",


### PR DESCRIPTION
Vendor the common Prometheus version package and use it to publish
the exporter version. We publish the version from the `-version`
flag, in the startup log, in the HTTP `User-Agent` header and in
the `mesos_exporter_build_info` metric.

This fixes #50.