### PR TITLE
mesos_master_task_states_current should be a gauge.

### DIFF
--- a/master.go
+++ b/master.go
@@ -396,7 +396,7 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			return nil
 		},
 
-		counter("master", "task_states_current", "Current number of tasks by state.", "state"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "task_states_current", "Current number of tasks by state.", "state"): func(m metricMap, c prometheus.Collector) error {
 			running, ok := m["master/tasks_running"]
 			if !ok {
 				log.WithField("metric", "master/tasks_running").Warn(LogErrNotFoundInMap)


### PR DESCRIPTION
The mesos_master_task_states_current metric is a snapshot of current
tasks, so it is a gauge not a counter.

This fixes #77.