### PR TITLE
Drop travis.ci tests for old Go version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: false
 language: go
 
 go:
-- "1.6.x"
-- "1.7.x"
-- "1.8.x"
 - "1.9.x"
 - "1.10.x"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prometheus Mesos Exporter
 
-[![Build Status](https://travis-ci.org/mesosphere/mesos_exporter.svg?branch=master)](https://travis-ci.org/mesosphere/mesos_exporter)
+[![Build Status](https://travis-ci.org/mesos/mesos_exporter.svg?branch=master)](https://travis-ci.org/mesos/mesos_exporter)
 
 Exporter for Mesos master and agent metrics.
 


### PR DESCRIPTION
The static analysis tests don't build under Go < 1.9,
so just drop the old releases.

This fixes #80.