### PR TITLE
Move the `task_killing` to `mesos_master_task_states_current`.

### DIFF
--- a/master.go
+++ b/master.go
@@ -376,23 +376,20 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/tasks_killed").Warn(LogErrNotFoundInMap)
 			}
-			killing, ok := m["master/tasks_killing"]
-			if !ok {
-				log.WithField("metric", "master/tasks_killing").Warn(LogErrNotFoundInMap)
-			}
 			lost, ok := m["master/tasks_lost"]
 			if !ok {
 				log.WithField("metric", "master/tasks_lost").Warn(LogErrNotFoundInMap)
 			}
+
 			c.(*settableCounterVec).Set(dropped, "dropped")
 			c.(*settableCounterVec).Set(errored, "errored")
 			c.(*settableCounterVec).Set(failed, "failed")
 			c.(*settableCounterVec).Set(finished, "finished")
-			c.(*settableCounterVec).Set(gone, "gone")
 			c.(*settableCounterVec).Set(goneByOperator, "gone_by_operator")
+			c.(*settableCounterVec).Set(gone, "gone")
 			c.(*settableCounterVec).Set(killed, "killed")
-			c.(*settableCounterVec).Set(killing, "killing")
 			c.(*settableCounterVec).Set(lost, "lost")
+
 			return nil
 		},
 
@@ -413,10 +410,18 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/tasks_unreachable").Warn(LogErrNotFoundInMap)
 			}
+
+			killing, ok := m["master/tasks_killing"]
+			if !ok {
+				log.WithField("metric", "master/tasks_killing").Warn(LogErrNotFoundInMap)
+			}
+
+			c.(*settableCounterVec).Set(killing, "killing")
 			c.(*settableCounterVec).Set(running, "running")
 			c.(*settableCounterVec).Set(staging, "staging")
 			c.(*settableCounterVec).Set(starting, "starting")
 			c.(*settableCounterVec).Set(unreachable, "unreachable")
+
 			return nil
 		},
 

--- a/slave.go
+++ b/slave.go
@@ -303,21 +303,19 @@ func newSlaveCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "slave/tasks_killed").Warn(LogErrNotFoundInMap)
 			}
-			killing, ok := m["slave/tasks_killing"]
-			if !ok {
-				log.WithField("metric", "slave/tasks_killing").Warn(LogErrNotFoundInMap)
-			}
+
 			lost, ok := m["slave/tasks_lost"]
 			if !ok {
 				log.WithField("metric", "slave/tasks_lost").Warn(LogErrNotFoundInMap)
 			}
+
 			c.(*settableCounterVec).Set(errored, "errored")
 			c.(*settableCounterVec).Set(failed, "failed")
 			c.(*settableCounterVec).Set(finished, "finished")
 			c.(*settableCounterVec).Set(gone, "gone")
 			c.(*settableCounterVec).Set(killed, "killed")
-			c.(*settableCounterVec).Set(killing, "killing")
 			c.(*settableCounterVec).Set(lost, "lost")
+
 			return nil
 		},
 		counter("slave", "task_states_current", "Current number of tasks by state.", "state"): func(m metricMap, c prometheus.Collector) error {
@@ -333,9 +331,16 @@ func newSlaveCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "slave/tasks_starting").Warn(LogErrNotFoundInMap)
 			}
+			killing, ok := m["slave/tasks_killing"]
+			if !ok {
+				log.WithField("metric", "slave/tasks_killing").Warn(LogErrNotFoundInMap)
+			}
+
+			c.(*settableCounterVec).Set(killing, "killing")
 			c.(*settableCounterVec).Set(running, "running")
 			c.(*settableCounterVec).Set(staging, "staging")
 			c.(*settableCounterVec).Set(starting, "starting")
+
 			return nil
 		},
 


### PR DESCRIPTION
The `master/tasks_killing` is a current task state gauge, but the exporter
represents it as a label on the `mesos_master_task_states_exit_total`
metric, which is a counter. It should be represented as a label on the
`mesos_master_task_states_current` gauge.

This fixes #78.