### PR TITLE
mesos 1.5.0: attempt to solve panic

### DIFF
--- a/master.go
+++ b/master.go
@@ -416,11 +416,11 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				log.WithField("metric", "master/tasks_killing").Warn(LogErrNotFoundInMap)
 			}
 
-			c.(*settableCounterVec).Set(killing, "killing")
-			c.(*settableCounterVec).Set(running, "running")
-			c.(*settableCounterVec).Set(staging, "staging")
-			c.(*settableCounterVec).Set(starting, "starting")
-			c.(*settableCounterVec).Set(unreachable, "unreachable")
+			c.(*prometheus.GaugeVec).WithLabelValues("killing").Set(killing)
+			c.(*prometheus.GaugeVec).WithLabelValues("running").Set(running)
+			c.(*prometheus.GaugeVec).WithLabelValues("staging").Set(staging)
+			c.(*prometheus.GaugeVec).WithLabelValues("starting").Set(starting)
+			c.(*prometheus.GaugeVec).WithLabelValues("unreachable").Set(unreachable)
 
 			return nil
 		},


### PR DESCRIPTION
I kept seeing this error everytime prometheus tried to scrape `/metrics`:
```
# docker logs -f system-mesos-exporter
panic: interface conversion: prometheus.Collector is *prometheus.GaugeVec, not *main.settableCounterVec

goroutine 18 [running]:
main.newMasterCollector.func20(0xc42019c330, 0x8ac000, 0xc42000e120, 0x0, 0x0)
        /go/src/github.com/mesosphere/mesos_exporter/master.go:419 +0x6f7
main.(*metricCollector).Collect(0xc420051cc0, 0xc4200668a0)
        /go/src/github.com/mesosphere/mesos_exporter/common.go:295 +0x1e7
github.com/mesosphere/mesos_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func2(0xc420026b10, 0xc4200668a0, 0x8ac200, 0xc420051cc0)
        /go/src/github.com/mesosphere/mesos_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:383 +0x61
created by github.com/mesosphere/mesos_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather
        /go/src/github.com/mesosphere/mesos_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:381 +0x302
```
After testing with this change the error went away and the mesos_exporter seems to be stable on master.
I tested this against `mesos 1.5.0`.