### PR TITLE
Fix interface conversion in task state metrics

### DIFF
--- a/master.go
+++ b/master.go
@@ -416,11 +416,11 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				log.WithField("metric", "master/tasks_killing").Warn(LogErrNotFoundInMap)
 			}
 
-			c.(*settableCounterVec).Set(killing, "killing")
-			c.(*settableCounterVec).Set(running, "running")
-			c.(*settableCounterVec).Set(staging, "staging")
-			c.(*settableCounterVec).Set(starting, "starting")
-			c.(*settableCounterVec).Set(unreachable, "unreachable")
+			c.(*prometheus.GaugeVec).WithLabelValues("running").Set(running)
+			c.(*prometheus.GaugeVec).WithLabelValues("staging").Set(staging)
+			c.(*prometheus.GaugeVec).WithLabelValues("starting").Set(starting)
+			c.(*prometheus.GaugeVec).WithLabelValues("unreachable").Set(unreachable)
+			c.(*prometheus.GaugeVec).WithLabelValues("killing").Set(killing)
 
 			return nil
 		},


### PR DESCRIPTION
Fixes: 

```
panic: interface conversion: prometheus.Collector is *prometheus.GaugeVec, not *main.settableCounterVec

goroutine 12 [running]:
main.newMasterCollector.func20(0xc4202c4120, 0x8abfe0, 0xc42000e080, 0x0, 0x0)
	/go/src/github.com/mesos/mesos_exporter/master.go:419 +0x6f7
main.(*metricCollector).Collect(0xc42009eb30, 0xc4200ba420)
	/go/src/github.com/mesos/mesos_exporter/common.go:295 +0x1e7
github.com/mesos/mesos_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func2(0xc420024470, 0xc4200ba420, 0x8ac1e0, 0xc42009eb30)
	/go/src/github.com/mesos/mesos_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:383 +0x61
created by github.com/mesos/mesos_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/go/src/github.com/mesos/mesos_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:381 +0x302
```